### PR TITLE
Use value returned from merge_right_only

### DIFF
--- a/lib/Data/ModeMerge/Mode/Base.pm
+++ b/lib/Data/ModeMerge/Mode/Base.pm
@@ -290,10 +290,10 @@ sub _merge_gen {
                          ($hr->{$k} && $mh->can("merge_right_only")))) {
                     # there's only left-side or right-side
                     my $meth = $hl->{$k} ? "merge_left_only" : "merge_right_only";
-                    my ($subnewkey, $v, $subbackup, $is_circular, $newmode) = $mh->$meth($k, $o[$i][1]); # XXX handle circular?
+                    my ($subnewkey, $v1, $subbackup, $is_circular, $newmode) = $mh->$meth($k, $o[$i][1]); # XXX handle circular?
                     next K unless defined($subnewkey);
                     $final_mode = $newmode;
-                    $v = $res;
+                    $v = $v1;
                 } else {
                     $final_mode = $o[$i][0];
                     $v = $o[$i][1];

--- a/t/51_merge_right_only.t
+++ b/t/51_merge_right_only.t
@@ -1,0 +1,49 @@
+#!perl;
+
+package Data::ModeMerge::Mode::RL;
+
+use 5.010;
+use strict;
+use warnings;
+use Mo qw(build default);
+extends 'Data::ModeMerge::Mode::NORMAL';
+
+sub name { 'RL' }
+
+sub default_prefix { '@' }
+
+sub default_prefix_re { qr/^\@/ }
+
+sub merge_right_only {
+	my ($self, $key, $right) = @_;
+
+	($key, ($right + 0) % 2 ? 'odd' : 'even', undef,undef,'NORMAL')
+}
+
+1;
+
+
+
+use strict;
+use warnings;
+use Test::More tests => 4;
+
+use lib './t';
+do 'testlib.pm';
+
+use Data::ModeMerge;
+
+$INC{'Data/ModeMerge/Mode/RL.pm'} = '';
+
+my $dm = Data::ModeMerge->new;
+$dm->register_mode('Data::ModeMerge::Mode::RL');
+$dm->combine_rules->{'NORMAL+RL'} = ['NORMAL','NORMAL'];
+
+
+merge_is({},{ '@test' => 0, }, { test => 'even' }, 'Test 0',  $dm);
+merge_is({},{ '@test' => 1, }, { test => 'odd' }, 'Test 1', $dm);
+merge_is({},{ '@test' => 2, }, { test => 'even' }, 'Test 2', $dm);
+merge_is({ test => 1 },{ '@test' => 2, }, { test => 2 }, 'Test with lhs', $dm);
+
+
+1;


### PR DESCRIPTION
When implementing merge_right_only in a Mode module, currently the value returned from the sub is not used for the out file.  This change uses this value.

Is this a valid change?  

Thanks in advance